### PR TITLE
[performance] Change atomic ordering of variable cmd_rx_entries to relaxed

### DIFF
--- a/src/ipc/src/lib.rs
+++ b/src/ipc/src/lib.rs
@@ -36,7 +36,7 @@ impl<T: Serialize> IpcSenderNotify<T> {
 
     pub fn send(&self, data: T) -> Result<(), bincode::Error> {
         self.inner.send(data)?;
-        self.entries.fetch_add(1, Ordering::AcqRel);
+        self.entries.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 }

--- a/src/koala/src/transport/engine.rs
+++ b/src/koala/src/transport/engine.rs
@@ -187,7 +187,7 @@ impl<'ctx> Engine for TransportEngine<'ctx> {
 
         self.dp_spin_cnt = 0;
 
-        if self.cmd_rx_entries.load(Ordering::Acquire) > 0 {
+        if self.cmd_rx_entries.load(Ordering::Relaxed) > 0 {
             self.backoff = std::cmp::max(1, self.backoff / 2);
             if self.flush_dp() {
                 return true;
@@ -314,7 +314,7 @@ impl<'ctx> TransportEngine<'ctx> {
         match self.cmd_rx.try_recv() {
             // handle request
             Ok(req) => {
-                self.cmd_rx_entries.fetch_sub(1, Ordering::AcqRel);
+                self.cmd_rx_entries.fetch_sub(1, Ordering::Relaxed);
                 let result = self.process_cmd(&req);
                 match result {
                     Ok(res) => self.cmd_tx.send(cmd::Response(Ok(res))),

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,6 @@
 TODO
 
-RAII
+Resource releasing
 - implement resource release (partially done)
 -[x] Finally find a solution to deal with Fd/Handle that can come from
      everywhere: use explicit open/close call to update the reference 
@@ -11,6 +11,28 @@ RAII
 		- Error::Disconnected
 		-[x] remove the blocking send/recv
 		-[x] expose current available count to read/write
+
+Performance & CPU efficiency
+- Use FnvHashMap in transport/engine
+-[x] Change to Ordering::Relaxed
+- GetSendComp() is currently busy spinning
+- Save CPU cycles in TransportEngine::run()
+- Control path is too slow
+-[x] balance poll_cq and post_send/recv, reduce redundant poll_cq
+    - <s>use seperate queues can work, but still can cause HOL among
+      multiple CQs</s>
+
+Thread-safety
+- Add spinlock to QueuePair, CompletionQueue... in libkoala
+- Most of the resources in transport/engine should be per-user, lock
+  or concurrent data structure is needed
+- Move CqBuffer from thread_local to lazy_static
+- Write a multi-threaded program to test the correctness
+
+Misc
+- Add AsHandle Trait so that open_or_create_resource can do sanity check
+- update all `trace!`s in TransportEngine::process_cmd
+- Handle conn_param
 
 Memory Registration
 -[x] Overlapped memory registration (two non-overlapped regions sharing
@@ -26,28 +48,6 @@ libkoala interface
     -[x] CmIdListener::incoming()
     -[x] CmIdListener::accept()
 
-Thread-safety
-- Add spinlock to QueuePair, CompletionQueue... in libkoala
-- Most of the resources in transport/engine should be per-user, lock
-  or concurrent data structure is needed
-- Move CqBuffer from thread_local to lazy_static
-- Write a multi-threaded program to test the correctness
-
-
-Performance
-- Use FnvHashMap in transport/engine
-- Change to Ordering::Relaxed
-- GetSendComp() is currently busy spinning
-- Save CPU cycles in TransportEngine::run()
-- Control path is too slow
--[x] balance poll_cq and post_send/recv, reduce redundant poll_cq
-    - <s>use seperate queues can work, but still can cause HOL among
-      multiple CQs</s>
-
-Misc
-- Add AsHandle Trait so that open_or_create_resource can do sanity check
-- update all `trace!`s in TransportEngine::process_cmd
-- Handle conn_param
-
 Engine Framework
 - What should Engine::run() return?
+- Blocking network APIs in transport engine may block the entire runtime


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've run `scripts/clippy.sh` to lint the changes in this PR.
- [ ] I've included any doc changes.
- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
