### PR TITLE
[Bug] Fix the issue of not being able to immediately exit after sigint received

### DIFF
--- a/src/koala/src/main.rs
+++ b/src/koala/src/main.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -22,13 +21,11 @@ struct Opts {
     config: PathBuf,
 }
 
-lazy_static::lazy_static! {
-    static ref TERMINATE:Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
-}
+static TERMINATE: AtomicBool = AtomicBool::new(false);
 
 extern "C" fn handle_sigint(sig: i32) {
     assert_eq!(sig, signal::SIGINT as i32);
-    TERMINATE.borrow().store(true, Ordering::Release);
+    TERMINATE.store(true, Ordering::Relaxed);
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. -->

## Why are these changes needed?
In the previous code, `exit_flag` will only be checked when the control loop is in `recv_with_credential_from`. This causes koala not to exit properly.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/clippy.sh` to lint the changes in this PR.
- [ ] I've included any doc changes.
- Testing Strategy
   - [x] Release tests
   - [ ] This PR is not tested :(
